### PR TITLE
standard exchange rates grammatical error

### DIFF
--- a/Heroes Handbook, Main File.txt
+++ b/Heroes Handbook, Main File.txt
@@ -6923,7 +6923,7 @@ A standard coin weighs about a third of an ounce, so fifty coins weigh a pound.
 |:--------------------|-----:|-----:|-----:|------:|---------:|
 |&nbsp; Copper (cp)   | 1    | 1/10 | 1/50 | 1/100 | 1/1000   |
 |&nbsp; Silver (sp)   | 10   | 1    | 1/5  | 1/10  | 1/100    |
-|&nbsp; Silver (sp)   | 50   | 5    | 1    | 1/2   | 1/20     |
+|&nbsp; Electrum (ep) | 50   | 5    | 1    | 1/2   | 1/20     |
 |&nbsp; Gold (gp)     | 100  | 10   | 2    | 1     | 1/10     |
 |&nbsp; Platinum (pp) | 1000 | 100  | 20   | 10    | 1        |
 


### PR DESCRIPTION
Silver was stated twice, changed one of them so that it says Electrum